### PR TITLE
group FQDN name for accessing CR

### DIFF
--- a/modules/infrastructure-moving-registry.adoc
+++ b/modules/infrastructure-moving-registry.adoc
@@ -16,7 +16,7 @@ You configure the registry Operator to deploy its pods to different nodes.
 . View the `config/instance` object:
 +
 ----
-$ oc get config/cluster -o yaml
+$ oc get configs.imageregistry.operator.openshift.io cluster -o yaml
 ----
 +
 The output resembles the following text:
@@ -54,7 +54,7 @@ status:
 . Edit the `config/instance` object:
 +
 ----
-$ oc edit config/cluster
+$ oc edit configs.imageregistry.operator.openshift.io cluster
 ----
 
 . Add the following lines of text the `spec` section of the object:


### PR DESCRIPTION
Good practice to access CR using group FQDN .

$ oc explain apiservices.spec.groupPriorityMinimum
KIND:     APIService
VERSION:  apiregistration.k8s.io/v1

FIELD:    groupPriorityMinimum <integer>

DESCRIPTION:
     GroupPriorityMininum is the priority this group should have at least.
     Higher priority means that the group is preferred by clients over lower
     priority ones. Note that other versions of this group might specify even
     higher GroupPriorityMininum values such that the whole group gets a higher
     priority. The primary sort is based on GroupPriorityMinimum, ordered
     highest number to lowest (20 before 10). **The secondary sort is based on the
     alphabetical comparison of the name of the object. (v1.bar before v1.foo)**
     We'd recommend something like: *.k8s.io (except extensions) at 18000 and
     PaaSes (OpenShift, Deis) are recommended to be in the 2000s


$ cat crd.yaml 
apiVersion: apiextensions.k8s.io/v1beta1
kind: CustomResourceDefinition
metadata:
  name: configs.example.com
spec:
  group: example.com
  scope: Cluster
  version: v1
  names:
    plural: configs
    singular: config
    kind: config

$ cat example.yaml 
apiVersion: example.com/v1
kind: config
metadata:
  name: cluster
  namespace: default
spec:
  replicas: 1

$ oc create -f crd.yaml 
customresourcedefinition.apiextensions.k8s.io/configs.example.com created

$ oc create -f example.yaml 
config.example.com/cluster created

$ oc get config/cluster -o yaml
apiVersion: example.com/v1
kind: config
metadata:
  creationTimestamp: "2020-07-29T14:09:22Z"
  generation: 1
  name: cluster
  resourceVersion: "4339523"
  selfLink: /apis/example.com/v1/configs/cluster
  uid: faf2a6d2-2dd3-42c0-9d5d-e0d66061b8d4
spec:
  replicas: 1
